### PR TITLE
Adding warning and solution

### DIFF
--- a/manual.md
+++ b/manual.md
@@ -61,7 +61,17 @@ adicionales:
 
 Y por último en el Vinculador, agregar lib a los directorios de bibliotecas
 adicionales:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Atención: Es posible que al realizar las operaciones descritas y utilizar glut.h
+nos aparezca el siguiente error:
+"error C2381: 'exit' : redefinition; __declspec(noreturn) differs"
+Para solucionarlo se nos propone incluir la librería stdlib.h de manera previa a
+glut.h para sobreescribir la funcionalidad de exit() (que es lo que en el fondo
+está causando tantos problemas):
 
+#include <stdlib.h>
+#include "glut.h"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Con esto ya tenemos el marco minimo para funcionar. En cualquier lugar bastará
 con
 


### PR DESCRIPTION
### ES)
Al intentar utilizar la librería y seguir los pasos indicados, me ha surgido el problema descrito en la advertencia (**"error C2381: 'exit' : redefinition; __declspec(noreturn) differs"**). Es un problema que sucede con las versiones de Visual Studio relativamente recientes y me parece que debe mencionarse. Una vez incluí stdlib.h previo a glut.h se solucionó. Sería una pena que alguien no llegase a probar esta librería por un cambio tan pequeño.

### EN)
When trying to use the library, the following error message appeared: **"error C2381: 'exit' : redefinition; __declspec(noreturn) differs"**. It's a problem that happens with relatively recent versions of Visual Studio, and once I applied the changes described everything worked. It would be a pity if someones didn't use the library for such a small change 